### PR TITLE
Move manifest linter to pipeline tasks

### DIFF
--- a/ci/credentials.example.yml
+++ b/ci/credentials.example.yml
@@ -6,6 +6,9 @@ shibboleth-production-private-region: SHIBBOLETH-PRODUCTION-PRIVATE-REGION
 shibboleth-production-private-bucket: SHIBBOLETH-PRODUCTION-PRIVATE-BUCKET
 shibboleth-production-private-passphrase: SHIBBOLETH-PRODUCTION-PRIVATE-PASSPHRASE
 
+pipeline-tasks-git-url: PIPELINE-TASKS-GIT-URL
+pipeline-tasks-git-branch: PIPELINE-TASKS-GIT-BRANCH
+
 cg-deploy-shibboleth-git-url: CG-DEPLOY-SHIBBOLETH-GIT-URL
 cg-deploy-shibboleth-git-branch: CG-DEPLOY-SHIBBOLETH-GIT-BRANCH
 

--- a/ci/generate-deployment-manifest.yml
+++ b/ci/generate-deployment-manifest.yml
@@ -21,5 +21,3 @@ run:
     shibboleth-config/generate-deployment-manifest.sh \
       common/secrets.yml \
       > shibboleth-manifest/manifest.yml
-    bosh-lint lint-manifest shibboleth-manifest/manifest.yml
-

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -16,6 +16,7 @@ jobs:
   plan:
   - aggregate:
     - get: master-bosh-root-cert
+    - get: pipeline-tasks
     - get: shibboleth-config
       trigger: true
     - get: common
@@ -31,6 +32,11 @@ jobs:
     file: shibboleth-config/ci/generate-deployment-manifest.yml
     params:
       ENVIRONMENT_FILE: shibboleth-config/shibboleth-staging.yml
+  - task: lint-manifest
+    file: pipeline-tasks/lint-manifest.yml
+    input_mapping:
+      pipeline-config: shibboleth-config
+      lint-manifest: shibboleth-manifest
   - put: shibboleth-staging-deployment
     params:
       cert: master-bosh-root-cert/master-bosh.crt
@@ -62,6 +68,7 @@ jobs:
   plan:
   - aggregate:
     - get: master-bosh-root-cert
+    - get: pipeline-tasks
     - get: shibboleth-config
       trigger: true
       passed: [deploy-shibboleth-staging]
@@ -80,6 +87,11 @@ jobs:
     file: shibboleth-config/ci/generate-deployment-manifest.yml
     params:
       ENVIRONMENT_FILE: shibboleth-config/shibboleth-production.yml
+  - task: lint-manifest
+    file: pipeline-tasks/lint-manifest.yml
+    input_mapping:
+      pipeline-config: shibboleth-config
+      lint-manifest: shibboleth-manifest
   - put: shibboleth-production-deployment
     params:
       cert: master-bosh-root-cert/master-bosh.crt
@@ -114,6 +126,12 @@ resources:
     bucket: {{shibboleth-production-private-bucket}}
     region_name: {{shibboleth-production-private-region}}
     versioned_file: master-bosh.crt
+
+- name: pipeline-tasks
+  type: git
+  source:
+    uri: {{pipeline-tasks-git-url}}
+    branch: {{pipeline-tasks-git-branch}}
 
 - name: common-staging
   type: cg-common


### PR DESCRIPTION
Run bosh-lint as a task in staging and production deploys instead of in manifest generation script.