### PR TITLE
update pipeline and BOSH manifest to use Jammy stemcell

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -16,7 +16,7 @@ update:
 
 stemcells:
 - alias: default
-  os: ubuntu-bionic
+  os: ubuntu-jammy
   version: latest
 
 instance_groups:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -31,7 +31,7 @@ jobs:
       trigger: true
     - get: secureproxy-release
       trigger: true
-    - get: shibboleth-stemcell-bionic
+    - get: shibboleth-stemcell-jammy
       trigger: true
   - put: shibboleth-development-deployment
     params:
@@ -43,7 +43,7 @@ jobs:
       - cg-s3-shibboleth-release/*.tgz
       - secureproxy-release/*.tgz
       stemcells:
-      - shibboleth-stemcell-bionic/*.tgz
+      - shibboleth-stemcell-jammy/*.tgz
   - task: acceptance-tests
     file: shibboleth-deployment-src/ci/acceptance_tests.yml
     params:
@@ -90,7 +90,7 @@ jobs:
     - get: secureproxy-release
       trigger: true
       passed: [deploy-shibboleth-development]
-    - get: shibboleth-stemcell-bionic
+    - get: shibboleth-stemcell-jammy
       trigger: true
       passed: [deploy-shibboleth-development]
   - put: shibboleth-staging-deployment
@@ -103,7 +103,7 @@ jobs:
       - cg-s3-shibboleth-release/*.tgz
       - secureproxy-release/*.tgz
       stemcells:
-      - shibboleth-stemcell-bionic/*.tgz
+      - shibboleth-stemcell-jammy/*.tgz
   - task: acceptance-tests
     file: shibboleth-deployment-src/ci/acceptance_tests.yml
     params:
@@ -150,7 +150,7 @@ jobs:
     - get: secureproxy-release
       trigger: true
       passed: [deploy-shibboleth-staging]
-    - get: shibboleth-stemcell-bionic
+    - get: shibboleth-stemcell-jammy
       trigger: true
       passed: [deploy-shibboleth-staging]
   - put: shibboleth-production-deployment
@@ -163,7 +163,7 @@ jobs:
       - cg-s3-shibboleth-release/*.tgz
       - secureproxy-release/*.tgz
       stemcells:
-      - shibboleth-stemcell-bionic/*.tgz
+      - shibboleth-stemcell-jammy/*.tgz
   - task: acceptance-tests
     file: shibboleth-deployment-src/ci/acceptance_tests.yml
     params:
@@ -208,10 +208,10 @@ resources:
     branch: ((cg-deploy-shibboleth-git-branch))
     commit_verification_keys: ((cloud-gov-pgp-keys))
 
-- name: shibboleth-stemcell-bionic
+- name: shibboleth-stemcell-jammy
   type: bosh-io-stemcell
   source:
-    name: bosh-aws-xen-hvm-ubuntu-bionic-go_agent
+    name: bosh-aws-xen-hvm-ubuntu-jammy-go_agent
 
 - name: cg-s3-shibboleth-release
   type: s3-iam


### PR DESCRIPTION
Related to https://github.com/cloud-gov/product/issues/2458

## Changes Proposed

- update pipeline and BOSH manifest to use Ubuntu Jammy stemcell

## Security Considerations

Ubuntu Bionic stemcells are EOL in April 2023, so we need to upgrade to Ubuntu Jammy stemcells to continue receiving security patches and updates
