### PR TITLE
Add snort rule to block 41497

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -46,6 +46,10 @@ instance_groups:
         - 'drop tcp $EXTERNAL_NET any -> $HOME_NET $HTTP_PORTS (msg:"SERVER-WEBAPP WordPress get_post authentication bypass attempt"; flow:to_server,established; content:"/wp-json/"; fast_pattern:only; http_uri; content:"id="; nocase; http_uri; pcre:"/[?&]id=[^&]*?[^\d&]/Ui"; metadata:policy balanced-ips drop, policy connectivity-ips drop, policy max-detect-ips drop, policy security-ips drop, ruleset community, service http; reference:url,wordpress.org/news/2017/01/wordpress-4-7-2-security-release/; classtype:web-application-attack; sid:41495000; rev:2;)'
         - 'suppress gen_id 1, sig_id 59948'
         - 'drop tcp $EXTERNAL_NET any -> $HOME_NET $HTTP_PORTS (msg:"SERVER-WEBAPP Atlassian Confluence OGNL expression injection attempt"; flow:to_server,established; content:"${"; http_uri; content:"com.opensymphony."; distance:0; fast_pattern; http_uri; content:"|28|"; distance:0; http_uri; content:"}"; distance:0; http_uri; pcre:"/\x24\x7b[^\x7d]*?com\x2eopensymphony\x2e(xwork2|webwork)\x2e(Servlet)?ActionContext[^\x7d]*?\x28/Ui"; metadata:policy balanced-ips drop, policy max-detect-ips drop, policy security-ips drop, ruleset community, service http; reference:cve,2022-26134; classtype:attempted-user; sid:59948000; rev:1;)'
+        - 'suppress gen_id 1, sig_id 41497'
+        - 'drop tcp $EXTERNAL_NET any -> $HOME_NET $HTTP_PORTS (msg:"SERVER-WEBAPP WordPress get_post authentication bypass attempt"; flow:to_server,established; content:"/wp-json/"; fast_pattern:only; http_uri; content:"|22|id|22|"; nocase; http_client_body; pcre:"/\x22id\x22\s*\x3A\s*\x22[^\x22]*?[^\d\x22]/Pi"; metadata:policy balanced-ips drop, policy connectivity-ips drop, policy max-detect-ips drop, policy security-ips drop, ruleset community, service http; reference:url,wordpress.org/news/2017/01/wordpress-4-7-2-security-release/; classtype:web-application-attack; sid:41497000d; rev:2;)'
+
+
 
   - name: secureproxy
     release: secureproxy


### PR DESCRIPTION
## Changes Proposed

- Add snort rule to drop packets matching rule 41497 instead of alerting
- Part of https://github.com/cloud-gov/product/issues/2836

-

## Security Considerations

Blocks attempted scan for WordPress for get_post
