### PR TITLE
Revert "Update tests to match new uaa"

### DIFF
--- a/SATS/integration_test.py
+++ b/SATS/integration_test.py
@@ -24,7 +24,13 @@ class IntegrationTestClient:
 
     def uaa_pick_idp(self) -> str:
         r = self.s.get(self.uaa_url + "/login")
-        r = self.s.get(f"{self.uaa_url}/saml2/authenticate/{self.idp_name}")
+        params = {
+            "returnIDParam": "idp",
+            "entityID": self.uaa_url[8:],
+            "idp": self.idp_name,
+            "isPassive": "true",
+        }
+        r = self.s.get(f"{self.uaa_url}/saml/discovery", params=params)
         soup = BeautifulSoup(r.text, features="html.parser")
         saml_request = soup.find(attrs={"name": "SAMLRequest"}).attrs["value"]
         relay_state = soup.find(attrs={"name": "RelayState"}).attrs["value"]
@@ -101,7 +107,7 @@ class IntegrationTestClient:
         handles registering totp if user does not have one currently
         returns a tuple of str, bool representing the user's totp_seed, and whether a new totp was registered
         """
-
+        
         r = self.uaa_pick_idp()
         soup = BeautifulSoup(r.text, features="html.parser")
         form = soup.find("form")


### PR DESCRIPTION
This reverts commit c4aa7b762ea65d1e5798d404fb8523b4c0bc149c.

## Changes Proposed

- So we can unpin shibby 
- Will need to reunvert when we move to new uaa with saml2
-

## Security Considerations

None