### PR TITLE
Remove wazuh agent

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -34,24 +34,17 @@ jobs:
     - get: shibboleth-stemcell-jammy
       trigger: true
     - get: general-task
-    - get: wazuh-agent
-      trigger: true
-    - get: wazuh-agent-release
-      trigger: true
   - put: shibboleth-development-deployment
     params:
       manifest: shibboleth-deployment-src/bosh/manifest.yml
       vars_files:
       - terraform-yaml/state.yml
       - shibboleth-deployment-src/bosh/varsfiles/development.yml
-      - wazuh-agent/manifest/dev-vars.yml
       releases:
       - cg-s3-shibboleth-release/*.tgz
       - secureproxy-release/*.tgz
       stemcells:
       - shibboleth-stemcell-jammy/*.tgz
-      ops_files:
-      - wazuh-agent/ops/add-wazuh-agent.yml
   - task: acceptance-tests
     image: general-task
     file: shibboleth-deployment-src/ci/acceptance_tests.yml
@@ -271,29 +264,6 @@ resources:
     repository: general-task
     aws_region: us-gov-west-1
     tag: latest
-
-- name: wazuh-agent
-  type: git
-  source:
-    branch: main
-    commit_verification_keys: ((cloud-gov-pgp-keys))
-    git_config:
-    - name: "user.name"
-      value: "cg-ci-bot"
-    - name: "user.email"
-      value: "no-reply@cloud.gov"
-    paths:
-    - manifest/dev-vars.yml
-    - ops/add-wazuh-agent.yml
-    private_key: ((cg-ci-bot-sshkey.private_key))
-    uri: git@github.com:cloud-gov/wazuh-agent.git
-    username: cg-ci-bot
-
-- name: wazuh-agent-release
-  type: s3-iam
-  source:
-    <<: *s3-release-params
-    regexp: wazuh-agent-(.*).tgz
 
 resource_types:
 - name: registry-image


### PR DESCRIPTION
## Changes proposed in this pull request:
- Remove wazuh agent from the deployment so the wazuh servers can be spun down
- Part of https://github.com/cloud-gov/private/issues/2740
-

## security considerations
Removes the wazuh agent from the deployment
