### PR TITLE
Acceptance tests - dev

### DIFF
--- a/SATS_v78/run_acceptance_tests.sh
+++ b/SATS_v78/run_acceptance_tests.sh
@@ -19,14 +19,10 @@ done
 pushd "$(dirname "${BASH_SOURCE[0]}")"
 
     if [[ -z "${NO_CREATE_ENV}" ]]; then
+        echo "Creating virtual environment..."
         python3 -m venv venv
         source venv/bin/activate
         python3 -m pip install -r requirements.txt
-
-        pushd ../
-            python3 -m pip install -r requirements.txt
-            python3 setup.py install
-        popd
     fi
     pytest -v
     return=$?

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -47,7 +47,7 @@ jobs:
       - shibboleth-stemcell-jammy/*.tgz
   - task: acceptance-tests
     image: general-task
-    file: shibboleth-deployment-src/ci/acceptance_tests.yml
+    file: shibboleth-deployment-src/ci/acceptance_tests_v78.yml
     params:
         UAA_USER: ((uaa-user))
         UAA_SECRET: ((uaa-client-secret-development))


### PR DESCRIPTION
## Changes Proposed

- Repoint dev acceptance tests to use the v78 version of the tests, newer UAA version change the pathing of some of the resources
- Removes errant second layer of attempting to load `requirements.txt` and `setup.py` which does not exist.  Likely artifacts from the uaa-extras job this was copied from.
- Part of https://github.com/cloud-gov/private/issues/2747

## Security Considerations

Only changes saml urls used, no security changes
