### PR TITLE
Switch prod to using v78 acceptance tests

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -151,7 +151,7 @@ jobs:
       - shibboleth-stemcell-jammy/*.tgz
   - task: acceptance-tests
     image: general-task
-    file: shibboleth-deployment-src/ci/acceptance_tests.yml
+    file: shibboleth-deployment-src/ci/acceptance_tests_v78.yml
     params:
         UAA_USER: ((uaa-user))
         UAA_SECRET: ((uaa-client-secret-production))


### PR DESCRIPTION
## Changes Proposed

- Final environment change after UAA v78 rollout to prod
- Part of https://github.com/cloud-gov/product/issues/2836
-

## Security Considerations

None, points acceptance tests to the correct url for this version of uaa
