### PR TITLE
create stemcell-os var to test fips rollout

### DIFF
--- a/bosh/manifest.yml
+++ b/bosh/manifest.yml
@@ -18,7 +18,7 @@ update:
 
 stemcells:
 - alias: default
-  os: ubuntu-jammy
+  os: ((stemcell-os))
   version: latest
 
 instance_groups:

--- a/bosh/varsfiles/development.yml
+++ b/bosh/varsfiles/development.yml
@@ -10,3 +10,4 @@ shibboleth-instances: 2
 disk-type: 5GB
 vm-type: t3.medium
 use-idp4: true
+stemcell-os: ubuntu-jammy-fips

--- a/bosh/varsfiles/production.yml
+++ b/bosh/varsfiles/production.yml
@@ -10,3 +10,4 @@ shibboleth-instances: 3
 disk-type: 5GB
 vm-type: t3.xlarge
 use-idp4: true
+stemcell-os: ubuntu-jammy

--- a/bosh/varsfiles/staging.yml
+++ b/bosh/varsfiles/staging.yml
@@ -10,3 +10,4 @@ shibboleth-instances: 2
 disk-type: 5GB
 vm-type: t3.large
 use-idp4: true
+stemcell-os: ubuntu-jammy


### PR DESCRIPTION
## Changes Proposed

- Creates `stemcell-os` variable for testing new stemcell variants including fips
- Uses the fips stemcell in dev

## Security Considerations

Fips is security
