### PR TITLE
use non fips stemcell - shibby fails on fips

### DIFF
--- a/bosh/varsfiles/development.yml
+++ b/bosh/varsfiles/development.yml
@@ -10,4 +10,4 @@ shibboleth-instances: 2
 disk-type: 5GB
 vm-type: t3.medium
 use-idp4: true
-stemcell-os: ubuntu-jammy-fips
+stemcell-os: ubuntu-jammy


### PR DESCRIPTION
## Changes Proposed

- Revert shibby in dev to non-fips stemcell as it fails on fips: https://github.com/cloud-gov/shibboleth-boshrelease/issues/168
 
## Security Considerations

no fips
